### PR TITLE
Fix typo in CLI command documentation

### DIFF
--- a/lib/ruby-lint/cli/analyze.rb
+++ b/lib/ruby-lint/cli/analyze.rb
@@ -1,6 +1,6 @@
 RubyLint::CLI.options.command :analyze do
   banner      'Usage: ruby-lint analyze [FILES] [OPTIONS]'
-  description 'Analysiss the source code of Ruby files'
+  description 'Analyze the source code of Ruby files'
 
   separator <<-EOF.chomp
 


### PR DESCRIPTION
Was just testing the linter and noticed this when looking at the params, so I fixed it.
