### PR TITLE
[CLEANUP] Use single quotes for simple strings

### DIFF
--- a/spec/fixtures/complex/rcap.rb
+++ b/spec/fixtures/complex/rcap.rb
@@ -46,10 +46,10 @@ module RCAP
     # * all Info objects contained in infos are valid
     class Alert < RCAP::Base::Alert
 
-      XMLNS = 'urn:oasis:names:tc:emergency:cap:1.2'
-      CAP_VERSION = '1.2'
+      XMLNS = "urn:oasis:names:tc:emergency:cap:1.2"
+      CAP_VERSION = "1.2"
 
-      STATUS_DRAFT    = 'Draft'
+      STATUS_DRAFT    = "Draft"
       # Valid values for status
       VALID_STATUSES = [ STATUS_ACTUAL, STATUS_EXERCISE, STATUS_SYSTEM, STATUS_TEST, STATUS_DRAFT ]
 

--- a/spec/fixtures/complex/slop.rb
+++ b/spec/fixtures/complex/slop.rb
@@ -112,7 +112,7 @@ class Slop
     #
     # Returns a new instance of Slop.
     def optspec(string, config = {})
-      warn '[DEPRECATED] `Slop.optspec` is deprecated and will be removed in version 4'
+      warn "[DEPRECATED] `Slop.optspec` is deprecated and will be removed in version 4"
       config[:banner], optspec = string.split(/^--+$/, 2) if string[/^--+$/]
       lines = optspec.split("\n").reject(&:empty?)
       opts  = Slop.new(config)
@@ -349,7 +349,7 @@ class Slop
   def run(callable = nil, &block)
     @runner = callable || block
     unless @runner.respond_to?(:call)
-      raise ArgumentError, 'You must specify a callable object or a block to #run'
+      raise ArgumentError, "You must specify a callable object or a block to #run"
     end
   end
 
@@ -464,8 +464,8 @@ class Slop
     if banner.nil?
       banner = "Usage: #{File.basename($0, '.*')}"
       banner << " #{@command}" if @command
-      banner << ' [command]' if @commands.any?
-      banner << ' [options]'
+      banner << " [command]" if @commands.any?
+      banner << " [options]"
     end
     if banner
       "#{banner}\n#{@separators[0] ? "#{@separators[0]}\n" : ''}#{optstr}"
@@ -511,7 +511,7 @@ class Slop
 
     if option
       option.count += 1 unless item.start_with?('--no-')
-      option.count += 1 if option.key[0, 3] == 'no-'
+      option.count += 1 if option.key[0, 3] == "no-"
       @trash << index
       @triggered_options << option
 


### PR DESCRIPTION
This change fixes all instances of the following warning from Rubocop:

"Prefer single-quoted strings when you don't need string interpolation or
special symbols."

Related: #97
