### PR TITLE
Use #name instead of #to_s when getting the name of constants.

### DIFF
--- a/lib/ruby-lint/inspector.rb
+++ b/lib/ruby-lint/inspector.rb
@@ -38,7 +38,7 @@ module RubyLint
     #
     def inspect_constants(source = constant, ignore = [])
       names          = []
-      source_name    = source.to_s
+      source_name    = source.name
       have_children  = []
       include_source = source != Object
 


### PR DESCRIPTION
The only constants that the Inspector should be looking at are of type Module or Class. Both of these built-in types respond to #name, but some gems (such as LibXML) create Modules in such a way that they implement #to_s with one (required) argument, whereas here we only call it with 0 arguments.

In most cases #to_s will be an alias for #name, and #name is really what we want anyway. Aside from that, many core classes and core functionality of Ruby will break if a gem maintainer chooses not to implement #name, whereas not implementing the zero-argument #to_s message appears to have no ill effects outside of causing ruby-lint to raise an exception when generating definitions for these gems.

Fixes [#133](https://github.com/YorickPeterse/ruby-lint/issues/133).
