### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/YorickPeterse/ruby-lint.png?branch=master)](https://travis-ci.org/YorickPeterse/ruby-lint)
 [![Code Climate](https://codeclimate.com/github/YorickPeterse/ruby-lint.png)](https://codeclimate.com/github/YorickPeterse/ruby-lint)
+[![Inline docs](http://inch-ci.org/github/YorickPeterse/ruby-lint.png?branch=master)](http://inch-ci.org/github/YorickPeterse/ruby-lint)
 
 ruby-lint is a static code analysis tool for Ruby. It is inspired by tools such
 as jshint, flake8 and similar tools. ruby-lint primarily focuses on logic


### PR DESCRIPTION
Hi Yorick,

this patch adds a docs badge to the README to show off inline-documentation to potential contributors: [![Inline docs](http://inch-ci.org/github/YorickPeterse/ruby-lint.png)](http://inch-ci.org/github/YorickPeterse/ruby-lint)

The badge links to [Inch CI](http://inch-ci.org), a project that tries to raise the visibility of inline-docs to encourage aspiring Rubyists to document their code. Your status page is http://inch-ci.org/github/YorickPeterse/ruby-lint/

Inch CI is still in its infancy, but already used by projects like [Bundler](https://github.com/bundler/bundler), [Guard](https://github.com/guard/guard), [Haml](https://github.com/haml/haml), [Pry](https://github.com/pry/pry), and [ROM](https://github.com/rom-rb/rom).

What do you think?
