### PR TITLE
Replace Array#| with Array#+

### DIFF
--- a/lib/ruby-lint/definition/ruby_object.rb
+++ b/lib/ruby-lint/definition/ruby_object.rb
@@ -697,7 +697,9 @@ module RubyLint
         if parent.type == type and parent.name == name
           parent_definition = parent
         else
-          parent_definition = parent.lookup(type, name, true, exclude | [self])
+          exclude = exclude + [self] unless exclude.include?(self)
+
+          parent_definition = parent.lookup(type, name, true, exclude)
         end
 
         return parent_definition


### PR DESCRIPTION
This is primarily for performance reasons. It yields around a 23% improvement on a file with 300 violations.

Here is a benchmark using [readygo](https://github.com/garybernhardt/readygo):
```
lint check ticket
  Baseline: |                                                X-                |
  Current:  |                                                                X-|
            0                                                           13.288 s
```
Baseline (with this change) is around 9.6s.

From my understanding this will not have an impact on functionality even though there can be duplicates in `excludes`. There may be a performance impact on the `include?` call but the improvement seems to be worth it.