### PR TITLE
Add module_function to Module methods

### DIFF
--- a/lib/ruby-lint/definitions/core/module.rb
+++ b/lib/ruby-lint/definitions/core/module.rb
@@ -203,6 +203,10 @@ RubyLint.registry.register('Module') do |defs|
       method.define_block_argument('prc')
     end
 
+    klass.define_instance_method('module_function') do |method|
+      method.define_rest_argument('syms')
+    end
+
     klass.define_instance_method('name')
 
     klass.define_instance_method('private_class_method') do |method|


### PR DESCRIPTION
`ruby-lint` reports `"undefined method module_function"` when using [`module_function`](http://ruby-doc.org/core-2.2.0/Module.html). The [Ruby style guide](https://github.com/bbatsov/ruby-style-guide) recommends using `module_function` instead of `extend self` or `class << self` to turn instance methods into class methods.