### PR TITLE
Reduce min arg in parallel assignment. Fixes #147

### DIFF
--- a/lib/ruby-lint/analysis/argument_amount.rb
+++ b/lib/ruby-lint/analysis/argument_amount.rb
@@ -112,6 +112,12 @@ module RubyLint
           max = min + method.amount(:optarg) + method.amount(:restarg)
         end
 
+        # If the method follows the writer naming pattern with a '=' ending,
+        # the parser generates send nodes with one less argument than needed in
+        # the case of parallel assignment. Here reducing minimum prevents false
+        # positive warnings to be generated.
+        min -= 1 if method.name =~ /=$/
+
         return min, max
       end
 

--- a/spec/ruby-lint/analysis/argument_amount_spec.rb
+++ b/spec/ruby-lint/analysis/argument_amount_spec.rb
@@ -128,4 +128,15 @@ example(&block)
 
     report.entries.empty?.should == true
   end
+
+  it 'ignores one required argument in parallel assignment' do
+    code = <<-CODE
+h = Hash.new
+h[1], h[2] = 1, 2
+    CODE
+
+    report = build_report(code, RubyLint::Analysis::ArgumentAmount)
+
+    report.entries.empty?.should == true
+  end
 end


### PR DESCRIPTION
When parallel assignment is used together with write syntactic sugar,
ie. method names ending with '=' followed by an argument, the parser
generates a masgn node which contain the send nodes with one less
argument than expected. Those arguments are gathered as an array in the
second child of masgn node.

Examples:
```ruby
h = Hash.new
h[1], h[2] = 1, 2
# s(:masgn,
#   s(:mlhs,
#     s(:send,
#       s(:send, nil, :h), :[]=,
#         s(:int, 1)),   # Here normally we would have an extra argument.
#     s(:send,
#       s(:send, nil, :h), :[]=,
#         s(:int, 2))),  # Here normally we would have an extra argument.
#   s(:array,
#     s(:int, 3),
#     s(:int, 4)))

# Same problem occurs in
class Hey
  def x=(_); end
end

h = Hey.new
h.x, h.x = 1, 2
```

This commit fixes that by reducing the required argument size by one on
such sugared method names.

It also reduces the sensitivity of the analysis in the case of a single writer
method usage, but that would be a syntax error anyway.

A better fix would involve having access to the parent node, so we can
check if it is a parallel assignment, or starting the analysis on a higher
up node.