### PR TITLE
Fix sorting of report entries

### DIFF
--- a/lib/ruby-lint/report/entry.rb
+++ b/lib/ruby-lint/report/entry.rb
@@ -67,7 +67,7 @@ module RubyLint
       # @return [Numeric]
       #
       def <=>(other)
-        return (filename <=> other.filename) <=> (other.line <=> line)
+        [filename, line] <=> [other.filename, other.line]
       end
     end # Entry
   end # Report

--- a/spec/ruby-lint/report/entry_spec.rb
+++ b/spec/ruby-lint/report/entry_spec.rb
@@ -55,4 +55,60 @@ describe RubyLint::Report::Entry do
     entries[4].file.should  == 'c.rb'
     entries[4].level.should == :error
   end
+
+  describe '#<=>' do
+    it 'compares smaller file name, smaller line number' do
+      a = RubyLint::Report::Entry.new(:file => 'a.rb', :line => 1)
+      b = RubyLint::Report::Entry.new(:file => 'b.rb', :line => 2)
+      (a<=>b).should < 0
+    end
+
+    it 'compares smaller file name, equal line number' do
+      a = RubyLint::Report::Entry.new(:file => 'a.rb', :line => 1)
+      b = RubyLint::Report::Entry.new(:file => 'b.rb', :line => 1)
+      (a<=>b).should < 0
+    end
+
+    it 'compares smaller file name, bigger line number' do
+      a = RubyLint::Report::Entry.new(:file => 'a.rb', :line => 2)
+      b = RubyLint::Report::Entry.new(:file => 'b.rb', :line => 1)
+      (a<=>b).should < 0
+    end
+
+    it 'compares equal file name, smaller line number' do
+      a = RubyLint::Report::Entry.new(:file => 'a.rb', :line => 1)
+      b = RubyLint::Report::Entry.new(:file => 'a.rb', :line => 2)
+      (a<=>b).should < 0
+    end
+
+    it 'compares equal file name, equal line number' do
+      a = RubyLint::Report::Entry.new(:file => 'a.rb', :line => 1)
+      b = RubyLint::Report::Entry.new(:file => 'a.rb', :line => 1)
+      (a<=>b).should == 0
+    end
+
+    it 'compares equal file name, bigger line number' do
+      a = RubyLint::Report::Entry.new(:file => 'a.rb', :line => 2)
+      b = RubyLint::Report::Entry.new(:file => 'a.rb', :line => 1)
+      (a<=>b).should > 0
+    end
+
+    it 'compares bigger file name, smaller line number' do
+      a = RubyLint::Report::Entry.new(:file => 'b.rb', :line => 1)
+      b = RubyLint::Report::Entry.new(:file => 'a.rb', :line => 2)
+      (a<=>b).should > 0
+    end
+
+    it 'compares bigger file name, equal line number' do
+      a = RubyLint::Report::Entry.new(:file => 'b.rb', :line => 1)
+      b = RubyLint::Report::Entry.new(:file => 'a.rb', :line => 1)
+      (a<=>b).should > 0
+    end
+
+    it 'compares bigger file name, bigger line number' do
+      a = RubyLint::Report::Entry.new(:file => 'b.rb', :line => 2)
+      b = RubyLint::Report::Entry.new(:file => 'a.rb', :line => 1)
+      (a<=>b).should > 0
+    end
+  end
 end


### PR DESCRIPTION
I noticed that report entries were sorted by line numbers within a file, but the files were sometimes intermixed:
```
RichText.rb: error: line 43, column 7: undefined method CutBlanks on String
URLRecode.rb: error: line 55, column 5: undefined method publish
URLRecode.rb: error: line 56, column 5: undefined method publish
URLRecode.rb: error: line 57, column 5: undefined method publish
URLRecode.rb: error: line 58, column 5: undefined method publish
URLRecode.rb: warning: line 61, column 3: unused constant URLRecode
RichText.rb: error: line 93, column 19: undefined method CutBlanks on String
RichText.rb: error: line 108, column 16: undefined method CutBlanks on String
RichText.rb: error: line 139, column 5: undefined method publish
RichText.rb: error: line 140, column 5: undefined method publish
```

It turns out that `RubyLint::Report::Entry#<=>`, and its tests, were wrong. This fixes it.