### PR TITLE
Mention method name in argument_amount report.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ the following output:
 
     test.rb: error: line 7, column 22: undefined instance variable @name
     test.rb: warning: line 12, column 1: unused local variable greeting
-    test.rb: error: line 14, column 1: wrong number of arguments (expected 0 but got 1)
+    test.rb: error: line 14, column 1: wrong number of arguments for 'greet' (expected 0 but got 1)
 
 ## ruby-lint versus RuboCop
 

--- a/lib/ruby-lint/analysis/argument_amount.rb
+++ b/lib/ruby-lint/analysis/argument_amount.rb
@@ -36,7 +36,8 @@ module RubyLint
           text = argument_text(method, given)
 
           error(
-            "wrong number of arguments (expected #{text} but got #{given})",
+            "wrong number of arguments for '#{method.name}' " \
+              "(expected #{text} but got #{given})",
             node
           )
         end

--- a/spec/ruby-lint/analysis/argument_amount_spec.rb
+++ b/spec/ruby-lint/analysis/argument_amount_spec.rb
@@ -16,7 +16,8 @@ example
 
     entry.line.should    == 4
     entry.column.should  == 1
-    entry.message.should == 'wrong number of arguments (expected 2 but got 0)'
+    entry.message.should == "wrong number of arguments for 'example' " \
+    "(expected 2 but got 0)"
   end
 
   it 'validates argument amounts when using optional arguments' do
@@ -34,8 +35,8 @@ example
 
     entry.line.should    == 4
     entry.column.should  == 1
-    entry.message.should == 'wrong number of arguments ' \
-      '(expected 2..3 but got 0)'
+    entry.message.should == "wrong number of arguments for 'example' " \
+      "(expected 2..3 but got 0)"
   end
 
   it 'validates argument amounts when using rest arguments' do
@@ -53,8 +54,8 @@ example
 
     entry.line.should    == 4
     entry.column.should  == 1
-    entry.message.should == 'wrong number of arguments ' \
-      '(expected 2 but got 0)'
+    entry.message.should == "wrong number of arguments for 'example' " \
+      "(expected 2 but got 0)"
   end
 
   it 'validates argument amounts when using a required and rest argument' do
@@ -108,11 +109,13 @@ Person.new(10, 20)
 
     first.line.should    == 6
     first.column.should  == 1
-    first.message.should == 'wrong number of arguments (expected 1 but got 0)'
+    first.message.should == "wrong number of arguments for 'initialize' " \
+      "(expected 1 but got 0)"
 
     second.line.should    == 7
     second.column.should  == 1
-    second.message.should == 'wrong number of arguments (expected 1 but got 2)'
+    second.message.should == "wrong number of arguments for 'initialize' " \
+      "(expected 1 but got 2)"
   end
 
   it 'ignores block arguments' do


### PR DESCRIPTION
Other analysis classes name the language element they report on but ArgumentAmount did not.

Before:
> test.rb: error: line 14, column 1: wrong number of arguments (expected 0 but got 1)

After:
 > test.rb: error: line 14, column 1: wrong number of arguments for 'greet' (expected 0 but got 1)

I have also considered to distinguish class and instance methods but opted for simplicity.
> ... for '#greet' ...
> ... for '.greet' ...
