### PR TITLE
Do not stop parsing all files on a syntax warning (#148).

### DIFF
--- a/lib/ruby-lint/runner.rb
+++ b/lib/ruby-lint/runner.rb
@@ -30,12 +30,6 @@ module RubyLint
 
       parser.consumer = proc do |diag|
         report_diagnostic(diag, report)
-
-        # FIXME: there's a bug in the pure Ruby version of Racc causing it hang
-        # after detecting a syntax error (it stays forever in recovery mode).
-        # To work around this we'll have to bail out after detecting the first
-        # syntax error.
-        return presenter.present(report)
       end
 
       files.each do |file|


### PR DESCRIPTION
This effectively reverts commit 310111a.

Travis tests do not show a problem with syntactically erroneous test files (spec/fixtures/syntax_error.rb)

If the Racc problems were to resurface, we should
- bail out on syntax errors but not warnings
- resume parsing the next file (possibly using one parser per one file)
- if all else fails, explicitly tell the user we could not complete the
  parse