### PR TITLE
Explicit mapping of constants to files.

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -148,3 +148,15 @@ Example:
     ---
     ignore_paths:
       - lib/ruby-lint/definitions
+
+### constant_paths
+
+In cases when your constants are defined in files that are not named according
+to the conventions, use `constant_path` to explicitly set where a constant
+should be found. It is a mapping from constant names to single files or to
+lists of files:
+
+    ---
+    constant_paths:
+      DNSServer: lib/mynet/dns_server.rb
+      DNSServerError: lib/mynet/dns_server.rb

--- a/lib/ruby-lint/configuration.rb
+++ b/lib/ruby-lint/configuration.rb
@@ -17,7 +17,7 @@ module RubyLint
   #  @return [Array]
   #
   # @!attribute [r] constant_paths
-  #  @return [Hash<String,Array<String>>] files containing a given constant
+  #  @return [Hash{String=>Array<String>}] files containing a given constant
   #
   # @!attribute [rw] debug
   #  @return [TrueClass|FalseClass]

--- a/lib/ruby-lint/configuration.rb
+++ b/lib/ruby-lint/configuration.rb
@@ -16,6 +16,9 @@ module RubyLint
   # @!attribute [r] directories
   #  @return [Array]
   #
+  # @!attribute [r] constant_paths
+  #  @return [Hash<String,Array<String>>] files containing a given constant
+  #
   # @!attribute [rw] debug
   #  @return [TrueClass|FalseClass]
   #
@@ -24,6 +27,7 @@ module RubyLint
   #
   class Configuration
     attr_reader :analysis_classes, :report_levels, :presenter, :directories
+    attr_reader :constant_paths
 
     attr_accessor :debug, :ignore_paths
 
@@ -115,6 +119,7 @@ module RubyLint
       @presenter        ||= default_presenter
       @directories      ||= default_directories
       @ignore_paths     ||= []
+      @constant_paths   ||= {}
     end
 
     ##
@@ -206,6 +211,11 @@ module RubyLint
       end
 
       @directories = valid
+    end
+
+    def constant_paths=(constant_paths)
+      # ensure that the values are arrays, make them of single elements in yaml
+      @constant_paths = constant_paths.map {|k,v| [k, Array(v)]}.to_h
     end
 
     ##

--- a/lib/ruby-lint/constant_loader.rb
+++ b/lib/ruby-lint/constant_loader.rb
@@ -11,9 +11,10 @@ module RubyLint
   # Global variables are also bootstrapped.
   #
   # @!attribute [r] loaded
-  #  @return [Set] Set containing the loaded constants.
+  #  @return [Set<String>] Set containing the loaded constants.
   #
   # @!attribute [r] definitions
+  #  (initialized via {Iterator#initialize})
   #  @return [RubyLint::Definition::RubyObject]
   #
   class ConstantLoader < Iterator
@@ -22,14 +23,14 @@ module RubyLint
     ##
     # Built-in definitions that should be bootstrapped.
     #
-    # @return [Array]
+    # @return [Array<String>]
     #
     BOOTSTRAP_CONSTS = %w{Module Class Kernel BasicObject Object}
 
     ##
     # List of global variables that should be bootstrapped.
     #
-    # @return [Array]
+    # @return [Array<String>]
     #
     BOOTSTRAP_GVARS = [
       '$!', '$$', '$&', '$\'', '$*', '$+', '$,', '$-0', '$-F', '$-I', '$-K',

--- a/lib/ruby-lint/constant_path.rb
+++ b/lib/ruby-lint/constant_path.rb
@@ -65,7 +65,7 @@ module RubyLint
     end
 
     ##
-    # Returns a String containing the full constant path, e.g.
+    # Returns a String containing the full constant path, for example
     # "RubyLint::Runner".
     #
     # @return [String]

--- a/lib/ruby-lint/definition/registry.rb
+++ b/lib/ruby-lint/definition/registry.rb
@@ -9,10 +9,12 @@ module RubyLint
     #  @return [Array] List of directories to search in for definitions.
     #
     # @!attribute [r] loaded_constants
-    #  @return [Set] Set containing the constants loaded from the load path.
+    #  @return [Set<String>] Set containing the constants loaded from
+    #   the load path.
     #
     # @!attribute [r] registered
-    #  @return [Hash] Returns the registered definitions as a Hash. The keys
+    #  @return [Hash{String=>Proc}]
+    #   Returns the registered definitions as a Hash. The keys
     #   are set to the constant names, the values to `Proc` instances that,
     #   when evaluated, create the corresponding definitions.
     #
@@ -22,7 +24,7 @@ module RubyLint
       ##
       # The default load path to use.
       #
-      # @return [Array]
+      # @return [Array<String>]
       #
       DEFAULT_LOAD_PATH = [
         File.expand_path('../../definitions/core', __FILE__),
@@ -90,6 +92,7 @@ module RubyLint
       # found.
       #
       # @param [String] constant The name of the top level constant.
+      # @return [void]
       #
       def load(constant)
         return if include?(constant)

--- a/lib/ruby-lint/file_loader.rb
+++ b/lib/ruby-lint/file_loader.rb
@@ -30,7 +30,7 @@ module RubyLint
     # Called after a new instance of this class is created.
     #
     def after_initialize
-      @file_scanner = FileScanner.new(@directories, @ignore_paths)
+      @file_scanner = FileScanner.new(@directories, @ignore_paths, @constant_paths)
       @parser       = Parser.new
       @nodes        = []
       @paths        = Set.new

--- a/lib/ruby-lint/file_scanner.rb
+++ b/lib/ruby-lint/file_scanner.rb
@@ -39,7 +39,7 @@ module RubyLint
     # @param [Array] directories A collection of base directories to search in.
     # @param [Array] ignore A list of paths to ignore.
     #
-    def initialize(directories = self.class.default_directories, ignore = [])
+    def initialize(directories = self.class.default_directories, ignore = [], constant_paths = {})
       unless directories.respond_to?(:each)
         raise TypeError, 'Directories must be specified as an Enumerable'
       end
@@ -48,7 +48,7 @@ module RubyLint
       @ignore      = ignore || []
 
       # Hash that will contain the matching file paths for a given constant.
-      @constant_paths_cache = {}
+      @constant_paths_cache = constant_paths || {}
     end
 
     ##
@@ -154,7 +154,8 @@ module RubyLint
     end
 
     ##
-    # @return [Array]
+    # @param segment [String] file path segment
+    # @return [Array<String>] matching elements of glob cache
     #
     def match_globbed_files(segment)
       # Ensure that we match entire path segments. Just using the segment would

--- a/lib/ruby-lint/file_scanner.rb
+++ b/lib/ruby-lint/file_scanner.rb
@@ -4,10 +4,10 @@ module RubyLint
   # potentially define a given Ruby constant (path).
   #
   # @!attribute [r] directories
-  #  @return [Array]
+  #  @return [Array<String>]
   #
   # @!attribute [r] ignore
-  #  @return [Array]
+  #  @return [Array<String>]
   #
   class FileScanner
     attr_reader :directories, :ignore
@@ -16,12 +16,12 @@ module RubyLint
     # Array containing names of directories that (often) contain Ruby source
     # files.
     #
-    # @return [Array]
+    # @return [Array<String>]
     #
     RUBY_DIRECTORIES = %w{app lib}
 
     ##
-    # @return [Array]
+    # @return [Array<String>]
     #
     def self.default_directories
       directories = []
@@ -38,6 +38,7 @@ module RubyLint
     ##
     # @param [Array] directories A collection of base directories to search in.
     # @param [Array] ignore A list of paths to ignore.
+    # @param [Hash{String=>Array<String>}] constant_paths
     #
     def initialize(directories = self.class.default_directories, ignore = [], constant_paths = {})
       unless directories.respond_to?(:each)
@@ -57,7 +58,7 @@ module RubyLint
     # (e.g. `a.rb` comes before `foo/a.rb`).
     #
     # @param [String] constant
-    # @return [Array]
+    # @return [Array<String>]
     #
     def scan(constant)
       unless constant_paths_cached?(constant)
@@ -68,14 +69,14 @@ module RubyLint
     end
 
     ##
-    # @return [Array]
+    # @return [Array<String>]
     #
     def glob_cache
       @glob_cache ||= directories.empty? ? [] : glob_ruby_files
     end
 
     ##
-    # @return [Array]
+    # @return [Array<String>]
     #
     def glob_ruby_files
       return Dir.glob("{#{directories.join(',')}}/**/*.rb")
@@ -167,6 +168,7 @@ module RubyLint
     end
 
     ##
+    # @param [String] constant
     # @return [TrueClass|FalseClass]
     #
     def constant_paths_cached?(constant)

--- a/lib/ruby-lint/runner.rb
+++ b/lib/ruby-lint/runner.rb
@@ -83,7 +83,8 @@ module RubyLint
     def process_external_files(root_ast)
       loader = FileLoader.new(
         :directories  => configuration.directories,
-        :ignore_paths => configuration.ignore_paths
+        :ignore_paths => configuration.ignore_paths,
+        :constant_paths => configuration.constant_paths
       )
 
       nodes    = []

--- a/spec/fixtures/file_scanner/lib/mynet/dns_server.rb
+++ b/spec/fixtures/file_scanner/lib/mynet/dns_server.rb
@@ -1,0 +1,10 @@
+# an example of placing classes in files named slightly differently than
+# the snake_case convention
+
+# not in dnsserver.rb
+class DNSServer
+end
+
+# not in dnsserver_error.rb
+class DNSServerError
+end

--- a/spec/ruby-lint/file_scanner_spec.rb
+++ b/spec/ruby-lint/file_scanner_spec.rb
@@ -74,6 +74,17 @@ describe RubyLint::FileScanner do
       ]
     end
 
+    it 'finds a class that has an explicit file location' do
+      filename = fixture_path('file_scanner/lib/mynet/dns_server.rb')
+
+      scanner = described_class.new([@lib_dir], [], {'DNSServer'=>[filename]})
+      paths   = scanner.scan('DNSServer')
+
+      paths.should == [
+        filename
+      ]
+    end
+
     it 'ignores directories' do
       scanner = described_class.new([@lib_dir], [@lib_dir])
 


### PR DESCRIPTION
In cases when your constants are defined in files that are not named according to the conventions, use `constant_path` to explicitly set where a constant should be found. It is a mapping from constant names to single files or to lists of files:

ruby-lint.yml:

    ---
    constant_paths:
      DNSServer: lib/mynet/dns_server.rb
      DNSServerError: lib/mynet/dns_server.rb

Real world examples:
- https://github.com/mvidner/ruby-dbus/blob/ruby-lint/ruby-lint.yml
- https://github.com/yast/yast-yast2/blob/ruby-lint/ruby-lint.yml

One could argue that if a project needs such configuration then its file layout should be fixed. This may not be feasible socially, where a team maintaining it first needs to be sold on the idea of applying ruby-lint before making file layout changes. Or in case of yast-yast2 it is even prevented by the underlying library which bridges several languages apart from Ruby, and requires a peculiar file layout.

There may well be a better solution to this, involving changes to the logic that ruby-lint uses when analyzing constants and parsing files, but I felt this approach was simple enough, not breaking anything else.