### PR TITLE
do not crash for '$10' and bigger (#175)

### DIFF
--- a/lib/ruby-lint/constant_loader.rb
+++ b/lib/ruby-lint/constant_loader.rb
@@ -33,11 +33,11 @@ module RubyLint
     #
     BOOTSTRAP_GVARS = [
       '$!', '$$', '$&', '$\'', '$*', '$+', '$,', '$-0', '$-F', '$-I', '$-K',
-      '$-W', '$-a', '$-d', '$-i', '$-l', '$-p', '$-v', '$-w', '$.', '$/', '$0',
-      '$1', '$2', '$3', '$4', '$5', '$6', '$7', '$8', '$9', '$:', '$;', '$<',
-      '$=', '$>', '$?', '$@', '$DEBUG', '$FILENAME', '$KCODE',
+      '$-W', '$-a', '$-d', '$-i', '$-l', '$-p', '$-v', '$-w', '$.', '$/', '$:',
+      '$;', '$<', '$=', '$>', '$?', '$@', '$DEBUG', '$FILENAME', '$KCODE',
       '$LOADED_FEATURES', '$LOAD_PATH', '$PROGRAM_NAME', '$SAFE', '$VERBOSE',
-      '$\"', '$\\', '$_', '$`', '$stderr', '$stdin', '$stdout', '$~'
+      '$\"', '$\\', '$_', '$`', '$stderr', '$stdin', '$stdout', '$~', '$0'
+      # regexp's $<int> is lazy loaded when used as it is not limited (#175)
     ]
 
     ##

--- a/lib/ruby-lint/virtual_machine.rb
+++ b/lib/ruby-lint/virtual_machine.rb
@@ -352,6 +352,8 @@ module RubyLint
     #
     def on_nth_ref(node)
       var = definitions.lookup(:gvar, "$#{node.children[0]}")
+      # if number not found, then add it as there is no limit for them
+      var = definitions.define_global_variable(node.children[0]) if !var && node.children[0].is_a?(Fixnum)
 
       push_value(var.value)
     end

--- a/spec/ruby-lint/analysis/undefined_variables_spec.rb
+++ b/spec/ruby-lint/analysis/undefined_variables_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyLint::Analysis::UndefinedVariables do
   it 'adds an error for using an undefined instance variable' do
@@ -138,6 +138,13 @@ end
 
   it 'does not add errors when aliasing global variables' do
     code   = 'alias $ARGV $*'
+    report = build_report(code, RubyLint::Analysis::UndefinedVariables)
+
+    report.entries.empty?.should == true
+  end
+
+  it 'does not add errors when using regexp captured global variables' do
+    code   = '$10'
     report = build_report(code, RubyLint::Analysis::UndefinedVariables)
 
     report.entries.empty?.should == true

--- a/spec/ruby-lint/virtual_machine/global_variables_spec.rb
+++ b/spec/ruby-lint/virtual_machine/global_variables_spec.rb
@@ -9,7 +9,7 @@ describe RubyLint::VirtualMachine do
 
     it 'provides a list of default global variables' do
       @defs.lookup(:gvar, '$LOAD_PATH').is_a?(ruby_object).should == true
-      @defs.lookup(:gvar, '$9').is_a?(ruby_object).should         == true
+      @defs.lookup(:gvar, '$,').is_a?(ruby_object).should         == true
     end
   end
 end


### PR DESCRIPTION
fixes #175 . Idea of this fix is to add to definitions any time this variable will be used as it is not limited and at least for me checking regexp if it can produce so many captures is almost impossible.