### PR TITLE
Fix 'Not enough argument definitions' exception when parsing less usual constructs

### DIFF
--- a/lib/ruby-lint/variable_predicates.rb
+++ b/lib/ruby-lint/variable_predicates.rb
@@ -20,6 +20,7 @@ module RubyLint
     #
     RUBY_CLASSES = {
       :str    => 'String',
+      :dstr   => 'String',
       :sym    => 'Symbol',
       :int    => 'Fixnum',
       :float  => 'Float',

--- a/lib/ruby-lint/virtual_machine.rb
+++ b/lib/ruby-lint/virtual_machine.rb
@@ -103,7 +103,9 @@ module RubyLint
       :int,
       :float,
       :str,
+      :dstr,
       :sym,
+      :regexp,
       :true,
       :false,
       :nil,
@@ -446,6 +448,13 @@ module RubyLint
       method = scope.lookup(scope.method_call_type, 'self')
 
       push_value(method.return_value)
+    end
+
+    ##
+    # Pushes the return value of the block yielded to, that is, an unknown one.
+    #
+    def on_yield
+      push_unknown_value
     end
 
     ##

--- a/spec/ruby-lint/virtual_machine/assignments/return_values_spec.rb
+++ b/spec/ruby-lint/virtual_machine/assignments/return_values_spec.rb
@@ -38,6 +38,17 @@ number = example
     value.instance?.should == true
   end
 
+  it 'assigns a return value for a bare yield' do
+    code = <<-CODE
+number = yield
+    CODE
+
+    defs = build_definitions(code)
+
+    defs.lookup(:lvar, 'number').value.should_not == nil
+  end
+
+
   describe 'setting instance types for core Ruby types' do
     it 'creates a new String instance' do
       defs = build_definitions('number = "10"')
@@ -45,8 +56,31 @@ number = example
       defs.lookup(:lvar, 'number').value.instance?.should == true
     end
 
+    it 'creates a new interpolated String instance' do
+      defs = build_definitions('number = "#{1}#{0}"')
+
+      defs.lookup(:lvar, 'number').value.instance?.should == true
+    end
+
+    it 'creates a new heredoc String instance' do
+      code = <<-CODE
+number = <<EOS
+EOS
+      CODE
+
+      defs = build_definitions(code)
+
+      defs.lookup(:lvar, 'number').value.instance?.should == true
+    end
+
     it 'creates a new Symbol instance' do
       defs = build_definitions('number = :"10"')
+
+      defs.lookup(:lvar, 'number').value.instance?.should == true
+    end
+
+    it 'creates a new Regexp instance' do
+      defs = build_definitions('number = //')
 
       defs.lookup(:lvar, 'number').value.instance?.should == true
     end


### PR DESCRIPTION
Fixes #173.

Of course, (regexp ...) (dstr ...) and (yield) are actually pretty common. The virtual machine has ignored these constructs but it has worked in most cases because child nodes provided the value.

```rb
puts //            # (regexp (regopt))
/foo/i             # (regexp (str "foo") (regopt :i))
puts <<EOS         # (dstr)
EOS
puts "foo#{bar}"   # (dstr (str "foo") (begin (send nil :bar)))
```
