### PR TITLE
Absolute constant lookup (::Foo)

### DIFF
--- a/lib/ruby-lint/constant_loader.rb
+++ b/lib/ruby-lint/constant_loader.rb
@@ -102,7 +102,7 @@ module RubyLint
     # @param [RubyLint::Node] node
     #
     def on_const(node)
-      load_nested_constant(ConstantPath.new(node).root_node[1])
+      load_nested_constant(ConstantPath.new(node).to_s)
     end
 
     ##
@@ -129,13 +129,17 @@ module RubyLint
     # @param [String] constant name, possibly unqualified
     #
     def load_nested_constant(constant)
-      # ["A", "B", "C"] -> ["A::B::C", "A::B", "A"]
-      namespaces = module_nesting.size.downto(1).map do |n|
-        module_nesting.take(n).join("::")
-      end
+      if constant.start_with?("::")
+        constant = constant.sub(/^::/, "")
+      else
+        # ["A", "B", "C"] -> ["A::B::C", "A::B", "A"]
+        namespaces = module_nesting.size.downto(1).map do |n|
+          module_nesting.take(n).join("::")
+        end
 
-      namespaces.each do |ns|
-        load_constant("#{ns}::#{constant}")
+        namespaces.each do |ns|
+          load_constant("#{ns}::#{constant}")
+        end
       end
       load_constant(constant)
     end

--- a/lib/ruby-lint/constant_path.rb
+++ b/lib/ruby-lint/constant_path.rb
@@ -56,15 +56,6 @@ module RubyLint
     end
 
     ##
-    # Returns the very first segment of the constant path as an AST node.
-    #
-    # @return [RubyLint::AST::Node]
-    #
-    def root_node
-      return constant_segments.first
-    end
-
-    ##
     # Returns a String containing the full constant path, e.g.
     # "RubyLint::Runner".
     #

--- a/lib/ruby-lint/constant_path.rb
+++ b/lib/ruby-lint/constant_path.rb
@@ -40,7 +40,7 @@ module RubyLint
         type  = REMAP_TYPES.fetch(type, type)
         found = current.lookup(type, name, index == 0)
 
-        if found and found.const?
+        if found and (found.const? or found.type == :root)
           current = found
 
         # Local variables and the likes.

--- a/lib/ruby-lint/definition/ruby_object.rb
+++ b/lib/ruby-lint/definition/ruby_object.rb
@@ -278,6 +278,8 @@ module RubyLint
         if defines?(type, name)
           found = definitions[type][name]
 
+        elsif type == :cbase
+          found = top_scope
         # Look up the definition in the parent scope(s) (if any are set). This
         # takes the parents themselves also into account.
         elsif lookup_parent?(type) and lookup_parent
@@ -675,6 +677,12 @@ module RubyLint
         address = (object_id << 1).to_s(16)
 
         return %Q(#<#{self.class}:0x#{address} #{attributes.join(' ')}>)
+      end
+
+      def top_scope
+        return self if type == :root
+        scope = parents.last   # the enclosing scope
+        scope ? scope.top_scope : self
       end
 
       private

--- a/spec/ruby-lint/analysis/undefined_variables_spec.rb
+++ b/spec/ruby-lint/analysis/undefined_variables_spec.rb
@@ -67,6 +67,48 @@ A::B
     entry.message.should == 'undefined constant A::B'
   end
 
+  it 'does not add errors for absolute constants' do
+    code = <<-CODE
+module Project
+  class File
+    def self.Exists(filename)
+      ::File.exist?(filename)
+    end
+  end
+end
+
+fn = "foo"
+puts File.exist?(fn)
+puts ::File.exist?(fn)
+puts Project::File.Exists(fn)
+    CODE
+    report = build_report(code, RubyLint::Analysis::UndefinedVariables)
+
+    report.entries.empty?.should == true
+  end
+
+  it 'does not add errors for absolute constants, with multiple parents' do
+    code = <<-CODE
+module Project
+  include Comparable
+  class File < Enumerable
+    include Comparable
+    def self.Exists(filename)
+      ::File.exist?(filename)
+    end
+  end
+end
+
+fn = "foo"
+puts File.exist?(fn)
+puts ::File.exist?(fn)
+puts Project::File.Exists(fn)
+    CODE
+    report = build_report(code, RubyLint::Analysis::UndefinedVariables)
+
+    report.entries.empty?.should == true
+  end
+
   it 'does not depend on the order of variable definitions' do
     code = <<-CODE
 class Person

--- a/spec/ruby-lint/constant_loader_spec.rb
+++ b/spec/ruby-lint/constant_loader_spec.rb
@@ -84,6 +84,24 @@ describe RubyLint::ConstantLoader do
     end
   end
 
+  context 'iterating over an AST with ::PP' do
+    before do
+      @ast = s(:root, s(:const, s(:cbase), 'PP'))
+    end
+
+    it 'loads a constant' do
+      @loader.run([@ast])
+      @loader.loaded?('PP').should == true
+    end
+
+    it 'calls the correct callbacks' do
+      @loader.should_receive(:on_const)
+        .with(an_instance_of(RubyLint::AST::Node))
+
+      @loader.run([@ast])
+    end
+  end
+
   context 'loading scoped constants' do
     before do
       @registry.register('Foo') do |defs|

--- a/spec/ruby-lint/constant_loader_spec.rb
+++ b/spec/ruby-lint/constant_loader_spec.rb
@@ -84,6 +84,25 @@ describe RubyLint::ConstantLoader do
     end
   end
 
+  context 'iterating over an AST with PP::ObjectMixin' do
+    before do
+      @ast = s(:root, s(:const, s(:const, nil, 'PP'), 'ObjectMixin'))
+    end
+
+    it 'loads a constant' do
+      @loader.run([@ast])
+      @loader.loaded?('PP').should == true
+    end
+
+    it 'calls the correct callbacks' do
+      @loader.should_receive(:on_const)
+        .with(an_instance_of(RubyLint::AST::Node)).twice
+
+      @loader.run([@ast])
+    end
+  end
+
+
   context 'iterating over an AST with ::PP' do
     before do
       @ast = s(:root, s(:const, s(:cbase), 'PP'))

--- a/spec/ruby-lint/constant_path_spec.rb
+++ b/spec/ruby-lint/constant_path_spec.rb
@@ -1,13 +1,6 @@
 require 'spec_helper'
 
 describe RubyLint::ConstantPath do
-  example 'return the root node of a constant path' do
-    node = s(:const, s(:const, nil, :Foo), :Bar)
-    root = RubyLint::ConstantPath.new(node).root_node
-
-    root.should == [:const, 'Foo']
-  end
-
   example 'generate the name of a constant path' do
     node = s(:const, s(:const, nil, :Foo), :Bar)
     name = RubyLint::ConstantPath.new(node).to_s

--- a/spec/ruby-lint/constant_path_spec.rb
+++ b/spec/ruby-lint/constant_path_spec.rb
@@ -15,6 +15,13 @@ describe RubyLint::ConstantPath do
     name.should == 'Foo::Bar'
   end
 
+  example 'generate the name of an absolute constant path' do
+    node = s(:const, s(:cbase), :Foo)
+    name = RubyLint::ConstantPath.new(node).to_s
+
+    name.should == '::Foo'
+  end
+
   context 'resolving definitions' do
     before :all do
       @scope = ruby_object.new(:type => :const, :name => 'Example')

--- a/spec/ruby-lint/constant_path_spec.rb
+++ b/spec/ruby-lint/constant_path_spec.rb
@@ -24,7 +24,7 @@ describe RubyLint::ConstantPath do
 
   context 'resolving definitions' do
     before :all do
-      @scope = ruby_object.new(:type => :const, :name => 'Example')
+      @scope = ruby_object.new(:type => :root, :name => 'root')
       @foo   = @scope.define_constant('Foo')
       @bar   = @foo.define_constant('Bar')
 
@@ -42,6 +42,16 @@ describe RubyLint::ConstantPath do
 
     example 'resolve a path of purely constants' do
       node = s(:const, s(:const, nil, :Foo), :Bar)
+      defs = RubyLint::ConstantPath.new(node).resolve(@scope)
+
+      defs.is_a?(ruby_object).should == true
+
+      defs.name.should == 'Bar'
+      defs.type.should == :const
+    end
+
+    example 'resolve a path of an absolute constant' do
+      node = s(:const, s(:const, s(:cbase), :Foo), :Bar)
       defs = RubyLint::ConstantPath.new(node).resolve(@scope)
 
       defs.is_a?(ruby_object).should == true


### PR DESCRIPTION
This is a fix for #180.

It is built upon #184, so please see that one first.